### PR TITLE
FIX(): No required in API Requests

### DIFF
--- a/google-captcha.php
+++ b/google-captcha.php
@@ -571,6 +571,9 @@ if ( ! function_exists( 'gglcptch_is_recaptcha_required' ) ) {
 				( ! $is_user_logged_in || ! gglcptch_is_hidden_for_role() )
 			);
 
+		/* No required into API request */
+		$result = wp_is_json_request() ? false: $result;
+
 		return $result;
 	}
 }


### PR DESCRIPTION
Remove captcha in API Request (REST).

reCaptcha block request from jwt-auth to obtain login token (..../wp-json/jwt-auth/v1/token) .

https://es.wordpress.org/plugins/jwt-auth/

Steps to reproduce:

1. Install and activate both plugins.
2. Generate token through API Rest (..../wp-json/jwt-auth/v1/token)

![c3439ad2-1f71-4ed7-a957-11aec1df21bb](https://github.com/bestwebsoft/google-captcha-recaptcha-wordpress-plugin/assets/8200125/d4ee9ef3-fdcf-4d7d-9850-32423340d429)
